### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions-update.yml
+++ b/.github/workflows/actions-update.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.7
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/requirements-update.yml
+++ b/.github/workflows/requirements-update.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.7
       with:
         ref: development
 
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v5.1.0
       with:
         python-version: '3.11'
 
@@ -47,7 +47,7 @@ jobs:
           --output-file requirements.txt requirements.in
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v6.1.0
       with:
         token: ${{ secrets.GH_TOKEN }}
         base: development

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.7
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v3.3.0
 
     - name: Login to DockerHub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v3.2.0
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -44,7 +44,7 @@ jobs:
 
     - name: Build the image
       id: buildimage
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6.1.0
       with:
         load: true
         context: ./
@@ -53,7 +53,7 @@ jobs:
         tags: ${{ steps.setimagename.outputs.imagename }}
 
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.23.0
       with:
         image-ref: '${{ steps.setimagename.outputs.imagename }}'
         format: 'table'

--- a/.github/workflows/test-image-build.yml
+++ b/.github/workflows/test-image-build.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.1.7
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v3.3.0
 
     - name: Login to DockerHub
-      uses: docker/login-action@v3
+      uses: docker/login-action@v3.2.0
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}
@@ -44,7 +44,7 @@ jobs:
 
     - name: Build the image
       id: buildimage
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6.1.0
       with:
         context: ./
         file: ./Dockerfile


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.3.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.3.0)** on 2024-04-08T08:06:08Z
* **[aquasecurity/trivy-action](https://github.com/aquasecurity/trivy-action)** published a new release **[0.23.0](https://github.com/aquasecurity/trivy-action/releases/tag/0.23.0)** on 2024-06-17T22:54:28Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.1.0](https://github.com/actions/setup-python/releases/tag/v5.1.0)** on 2024-03-26T14:09:17Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.1.0](https://github.com/docker/build-push-action/releases/tag/v6.1.0)** on 2024-06-21T07:43:57Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v6.1.0](https://github.com/peter-evans/create-pull-request/releases/tag/v6.1.0)** on 2024-06-18T16:54:59Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.2.0](https://github.com/docker/login-action/releases/tag/v3.2.0)** on 2024-05-28T08:07:54Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
